### PR TITLE
共通レイアウトの作成（ヘッダー、フッター、サイドバー）

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -8,3 +8,126 @@
  *
  * Consider organizing styles into separate files for maintainability.
  */
+
+/* リセットと基本設定 */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.6;
+  color: #333;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ヘッダー */
+.header {
+  background-color: #2563eb;
+  color: white;
+  padding: 1rem 2rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.header-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+/* メインコンテナ */
+.main-container {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+/* サイドバー */
+.sidebar {
+  width: 250px;
+  background-color: #1e40af;
+  color: white;
+  padding: 1.5rem 0;
+  overflow-y: auto;
+}
+
+.sidebar-nav {
+  width: 100%;
+}
+
+.sidebar-menu {
+  list-style: none;
+}
+
+.sidebar-menu-item {
+  margin-bottom: 0.5rem;
+}
+
+.sidebar-link {
+  display: block;
+  padding: 0.75rem 1.5rem;
+  color: #e0e7ff;
+  text-decoration: none;
+  transition: all 0.2s;
+  border-left: 3px solid transparent;
+}
+
+.sidebar-link:hover {
+  background-color: #1e3a8a;
+  color: white;
+}
+
+.sidebar-link.active {
+  background-color: #1e3a8a;
+  border-left-color: #60a5fa;
+  color: white;
+  font-weight: 600;
+}
+
+/* メインコンテンツ */
+.content {
+  flex: 1;
+  padding: 2rem;
+  overflow-y: auto;
+  background-color: #f8fafc;
+}
+
+/* フッター */
+.footer {
+  background-color: #1e40af;
+  color: white;
+  padding: 1rem 2rem;
+  display: flex;
+  gap: 2rem;
+  justify-content: center;
+  align-items: center;
+}
+
+.footer-link {
+  color: #e0e7ff;
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.footer-link:hover {
+  color: white;
+}
+
+/* レスポンシブ対応 */
+@media (max-width: 768px) {
+  .main-container {
+    flex-direction: column;
+  }
+  
+  .sidebar {
+    width: 100%;
+    padding: 1rem 0;
+  }
+  
+  .content {
+    padding: 1rem;
+  }
+}

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,4 @@
+class HomeController < ApplicationController
+  def index
+  end
+end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -1,0 +1,2 @@
+module HomeHelper
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,0 +1,9 @@
+<div style="padding: 2rem;">
+  <h1 style="font-size: 2rem; font-weight: 600; margin-bottom: 1rem; color: #1e40af;">
+    QA-ToolKitへようこそ
+  </h1>
+  <p style="font-size: 1.125rem; color: #64748b; line-height: 1.75;">
+    テスト設計・準備の効率化ツールキットです。<br>
+    左のメニューから各機能をお選びください。
+  </p>
+</div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,0 +1,5 @@
+<footer class="footer">
+  <%= link_to "利用規約", "#", class: "footer-link" %>
+  <%= link_to "プライバシーポリシー", "#", class: "footer-link" %>
+  <%= link_to "お問い合わせ", "#", class: "footer-link" %>
+</footer>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,0 +1,3 @@
+<header class="header">
+  <h1 class="header-title">QA-ToolKit</h1>
+</header>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -1,0 +1,18 @@
+<aside class="sidebar">
+  <nav class="sidebar-nav">
+    <ul class="sidebar-menu">
+      <li class="sidebar-menu-item">
+        <%= link_to "バリデーションテキスト生成", "#", class: "sidebar-link #{'active' if current_page?(root_path)}" %>
+      </li>
+      <li class="sidebar-menu-item">
+        <%= link_to "柔軟なデータ生成", "#", class: "sidebar-link" %>
+      </li>
+      <li class="sidebar-menu-item">
+        <%= link_to "シンプルなダミーデータ生成", "#", class: "sidebar-link" %>
+      </li>
+      <li class="sidebar-menu-item">
+        <%= link_to "テストクラス分析サポート", "#", class: "sidebar-link" %>
+      </li>
+    </ul>
+  </nav>
+</aside>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "Runteq Final App" %></title>
+    <title><%= content_for(:title) || "QA-ToolKit" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="application-name" content="Runteq Final App">
+    <meta name="application-name" content="QA-ToolKit">
     <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -24,6 +24,13 @@
   </head>
 
   <body>
-    <%= yield %>
+    <%= render "layouts/header" %>
+    <div class="main-container">
+      <%= render "layouts/sidebar" %>
+      <main class="content">
+        <%= yield %>
+      </main>
+    </div>
+    <%= render "layouts/footer" %>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,5 @@ Rails.application.routes.draw do
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root "home#index"
 end

--- a/spec/helpers/home_helper_spec.rb
+++ b/spec/helpers/home_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the HomeHelper. For example:
+#
+# describe HomeHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe HomeHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Homes", type: :request do
+  describe "GET /index" do
+    it "returns http success" do
+      get "/home/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/home/index.html.erb_spec.rb
+++ b/spec/views/home/index.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "home/index.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
全ページ共通のレイアウト（ヘッダー、フッター、サイドバー）を実装しました。

## 変更内容
- `application.html.erb`にレイアウト構造を追加
- ヘッダー、サイドバー、フッターのパーシャルを作成
- 青を基調としたCSSスタイルを実装
- サイドバーのアクティブ状態を実装（選択中の項目をハイライト）
- ルートパス(`/`)の設定とHomeコントローラーを作成
- レスポンシブ対応（768px以下でモバイル表示）

## デザインの特徴
- **カラースキーム**: 青を基調としたデザイン
  - ヘッダー: `#2563eb`（明るい青）
  - サイドバー・フッター: `#1e40af`（濃い青）
  - アクティブ状態: 青い左ボーダー（`#60a5fa`）
- **レイアウト**: Flexboxを使用した柔軟なレイアウト
- **レスポンシブ**: モバイル端末でも見やすい表示

## 動作確認
- [x] ヘッダーが正しく表示される
- [x] サイドバーが正しく表示される
- [x] フッターが正しく表示される
- [x] サイドバーのアクティブ状態が機能する
- [x] レスポンシブ対応が機能する
- [x] トップページ(`/`)が正常に表示される

## スクリーンショット
<img width="1510" height="869" alt="スクリーンショット 2025-11-15 22 20 01" src="https://github.com/user-attachments/assets/6c1784bb-d94a-430a-8127-5f49ffe3fc57" />
