### PR TITLE
柔軟なデータ生成 画面作成と機能実装

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -355,6 +355,169 @@ body {
   background-color: #1e40af;
 }
 
+/* 柔軟なデータ生成ページのスタイル */
+.flexible-data-container {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.page-description {
+  color: #64748b;
+  font-size: 1rem;
+  margin-bottom: 2rem;
+}
+
+.flexible-form {
+  margin-bottom: 2rem;
+}
+
+.form-help {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-top: 0.5rem;
+}
+
+.form-input-small {
+  max-width: 200px;
+}
+
+.digit-selector {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.digit-selector input[type="radio"] {
+  display: none;
+}
+
+.digit-option {
+  padding: 0.75rem 1.5rem;
+  border: 2px solid #cbd5e1;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-weight: 600;
+  color: #64748b;
+  background-color: white;
+}
+
+.digit-selector input[type="radio"]:checked + .digit-option {
+  border-color: #2563eb;
+  background-color: #eff6ff;
+  color: #2563eb;
+}
+
+.digit-option:hover {
+  border-color: #94a3b8;
+}
+
+.error-message {
+  background-color: #fef2f2;
+  border-left: 4px solid #ef4444;
+  padding: 1.5rem;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: #991b1b;
+  font-weight: 500;
+}
+
+.error-icon {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+}
+
+.result-section {
+  background: white;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.result-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 2rem;
+  max-height: 400px;
+  overflow-y: auto;
+  padding: 0.5rem;
+  background-color: #f8fafc;
+  border-radius: 6px;
+}
+
+.result-list-item {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem;
+  background: white;
+  border-radius: 6px;
+  transition: all 0.2s;
+}
+
+.result-list-item:hover {
+  background-color: #eff6ff;
+  transform: translateX(4px);
+}
+
+.result-list-number {
+  font-weight: 600;
+  color: #64748b;
+  min-width: 2rem;
+  text-align: right;
+}
+
+.result-list-text {
+  flex: 1;
+  font-family: 'Courier New', monospace;
+  color: #1e293b;
+}
+
+.btn-icon {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.5rem;
+  border-radius: 4px;
+  transition: all 0.2s;
+  color: #64748b;
+}
+
+.btn-icon:hover {
+  background-color: #e2e8f0;
+  color: #2563eb;
+}
+
+.icon {
+  width: 20px;
+  height: 20px;
+}
+
+.result-textarea-container {
+  margin-top: 2rem;
+}
+
+.result-textarea {
+  width: 100%;
+  min-height: 150px;
+  padding: 1rem;
+  border: 2px solid #cbd5e1;
+  border-radius: 6px;
+  font-family: 'Courier New', monospace;
+  font-size: 0.875rem;
+  resize: vertical;
+  background-color: #f8fafc;
+}
+
+.result-textarea:focus {
+  outline: none;
+  border-color: #2563eb;
+}
+
 /* レスポンシブ対応 */
 @media (max-width: 768px) {
   .main-container {
@@ -398,5 +561,24 @@ body {
 
   .btn-copy {
     width: 100%;
+  }
+
+  .digit-selector {
+    flex-wrap: wrap;
+  }
+
+  .result-list-item {
+    padding: 0.5rem;
+  }
+
+  .result-list-number {
+    min-width: 1.5rem;
+  }
+
+  .custom-toast {
+    bottom: 1rem;
+    right: 1rem;
+    left: 1rem;
+    max-width: none;
   }
 }

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -51,6 +51,32 @@ class ToolsController < ApplicationController
     end
   end
 
+  def flexible_data
+    # ビューを表示するだけ
+  end
+
+  def generate_flexible_data
+    prefix = params[:prefix].to_s
+    sequence_digits = params[:sequence_digits].to_i
+    count = params[:count].to_i
+
+    # バリデーション
+    if count <= 0 || count > 1000
+      @error = "生成する件数は1〜1000の範囲で指定してください"
+      @generated_data = []
+    elsif sequence_digits <= 0 || sequence_digits > 10
+      @error = "連番の桁数は1〜10の範囲で指定してください"
+      @generated_data = []
+    else
+      @generated_data = generate_sequence_data(prefix, sequence_digits, count)
+      @error = nil
+    end
+
+    respond_to do |format|
+      format.turbo_stream
+    end
+  end
+
   private
 
   def generate_text_by_count(count, char_type)
@@ -148,6 +174,12 @@ class ToolsController < ApplicationController
     when "half_width_space" then "半角スペース"
     when "full_width_space" then "全角スペース"
     else ""
+    end
+  end
+
+  def generate_sequence_data(prefix, digits, count)
+    (1..count).map do |i|
+      "#{prefix}#{i.to_s.rjust(digits, '0')}"
     end
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -74,3 +74,27 @@ window.copyFullWidthSpace = function() {
     showToast('コピーに失敗しました', 'error');
   });
 };
+
+// 柔軟なデータ生成用のコピー関数
+window.copyAllFlexibleData = function() {
+  const textarea = document.getElementById('all-data-textarea');
+  if (textarea) {
+    const text = textarea.value;
+    navigator.clipboard.writeText(text).then(() => {
+      showToast('すべてのデータをコピーしました');
+    }).catch(err => {
+      showToast('コピーに失敗しました', 'error');
+    });
+  }
+};
+
+window.copySingleData = function(button) {
+  const listItem = button.closest('.result-list-item');
+  const text = listItem.querySelector('.result-list-text').dataset.text;
+  
+  navigator.clipboard.writeText(text).then(() => {
+    showToast('コピーしました: ' + text);
+  }).catch(err => {
+    showToast('コピーに失敗しました', 'error');
+  });
+};

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -5,7 +5,7 @@
         <%= link_to "バリデーションテキスト生成", root_path, class: "sidebar-link #{'active' if current_page?(root_path)}" %>
       </li>
       <li class="sidebar-menu-item">
-        <%= link_to "柔軟なデータ生成", "#", class: "sidebar-link" %>
+        <%= link_to "柔軟なデータ生成", tools_flexible_data_path, class: "sidebar-link #{'active' if current_page?(tools_flexible_data_path)}" %>
       </li>
       <li class="sidebar-menu-item">
         <%= link_to "シンプルなダミーデータ生成", "#", class: "sidebar-link" %>

--- a/app/views/tools/flexible_data.html.erb
+++ b/app/views/tools/flexible_data.html.erb
@@ -1,0 +1,48 @@
+<div class="flexible-data-container">
+  <h1 class="page-title">柔軟なデータ生成</h1>
+  <p class="page-description">よく使う個人情報をワンクリックで生成・コピーします。</p>
+
+  <%= form_with url: tools_generate_flexible_data_path, method: :post, data: { turbo_stream: true }, class: "flexible-form" do |f| %>
+    
+    <div class="form-section">
+      <h2 class="section-title">プレフィックス（接頭語）</h2>
+      
+      <div class="form-group">
+        <%= f.text_field :prefix, placeholder: "例: user-", class: "form-input", value: "user-" %>
+        <p class="form-help">生成されるデータの先頭に付く文字列</p>
+      </div>
+
+      <h2 class="section-title">連番の桁数</h2>
+      
+      <div class="form-group">
+        <div class="digit-selector">
+          <%= f.radio_button :sequence_digits, 1, id: "digit_1", checked: false %>
+          <%= f.label :sequence_digits, "1", for: "digit_1", class: "digit-option" %>
+          
+          <%= f.radio_button :sequence_digits, 2, id: "digit_2", checked: false %>
+          <%= f.label :sequence_digits, "2", for: "digit_2", class: "digit-option" %>
+          
+          <%= f.radio_button :sequence_digits, 3, id: "digit_3", checked: true %>
+          <%= f.label :sequence_digits, "3", for: "digit_3", class: "digit-option" %>
+        </div>
+        <p class="form-help">1桁: user-1, 2桁: user-01, 3桁: user-001</p>
+      </div>
+
+      <h2 class="section-title">生成する件数</h2>
+      
+      <div class="form-group">
+        <%= f.number_field :count, min: 1, max: 1000, value: 10, class: "form-input form-input-small", placeholder: "10" %>
+        <p class="form-help">1〜1000件まで指定可能</p>
+      </div>
+
+      <div class="button-group">
+        <%= f.submit "生成する", class: "btn btn-primary" %>
+        <button type="button" class="btn btn-secondary" onclick="copyAllFlexibleData()">コピー</button>
+      </div>
+    </div>
+
+  <% end %>
+
+  <!-- 結果表示エリア -->
+  <div id="flexible-results" class="results-container"></div>
+</div>

--- a/app/views/tools/generate_flexible_data.turbo_stream.erb
+++ b/app/views/tools/generate_flexible_data.turbo_stream.erb
@@ -1,0 +1,38 @@
+<%= turbo_stream.update "flexible-results" do %>
+  <% if @error %>
+    <div class="error-message">
+      <svg xmlns="http://www.w3.org/2000/svg" class="error-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+      <%= @error %>
+    </div>
+  <% elsif @generated_data.present? %>
+    <div class="result-section">
+      <div class="result-header">
+        <h3 class="result-title">生成結果（<%= @generated_data.length %>件）</h3>
+        <button type="button" class="btn btn-copy" onclick="copyAllFlexibleData()">
+          すべてコピー
+        </button>
+      </div>
+
+      <div class="result-list">
+        <% @generated_data.each_with_index do |data, index| %>
+          <div class="result-list-item">
+            <span class="result-list-number"><%= index + 1 %>.</span>
+            <span class="result-list-text" data-text="<%= data %>"><%= data %></span>
+            <button type="button" class="btn-icon" onclick="copySingleData(this)" title="コピー">
+              <svg xmlns="http://www.w3.org/2000/svg" class="icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+              </svg>
+            </button>
+          </div>
+        <% end %>
+      </div>
+
+      <div class="result-textarea-container">
+        <label class="form-label">すべてのデータ（改行区切り）</label>
+        <textarea id="all-data-textarea" class="result-textarea" readonly><%= @generated_data.join("\n") %></textarea>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,4 +14,6 @@ Rails.application.routes.draw do
   
   # Tools routes
   post "tools/generate_validation_text", to: "tools#generate_validation_text"
+  get "tools/flexible_data", to: "tools#flexible_data"
+  post "tools/generate_flexible_data", to: "tools#generate_flexible_data"
 end


### PR DESCRIPTION
## 概要
連番データを柔軟に生成できる機能を実装しました。

## 実装内容
- [x] プレフィックス（接頭語）設定機能
  - 自由に文字列を設定可能（例: user-, test-, data-）
  - デフォルト値: "user-"
- [x] 連番の桁数選択機能
  - 1桁、2桁、3桁から選択
  - ラジオボタンでクリックしやすいUI
  - 例: 1桁(user-1)、2桁(user-01)、3桁(user-001)
- [x] 生成件数指定機能
  - 1〜1000件まで指定可能
  - 数値入力フィールド
- [x] データ生成機能
  - 0埋め連番データを自動生成
  - Rubyの`rjust`メソッドで実装
- [x] コピー機能
  - 個別コピー: 各行のアイコンボタン
  - 一括コピー: ヘッダーの「すべてコピー」ボタン
  - テキストエリア: 選択コピーも可能
- [x] バリデーション機能
  - 件数: 1〜1000の範囲チェック
  - 桁数: 1〜10の範囲チェック
  - エラー時は赤いメッセージボックスで通知
- [x] UX最適化
  - トーストメッセージで視覚的フィードバック
  - スクロール可能なリスト（最大400px）
  - ホバーエフェクトでインタラクティブに
  - レスポンシブデザイン対応

## 技術仕様
- Turbo Streamsによる部分更新
- JavaScript Clipboard API
- カスタムラジオボタンデザイン
- エラーハンドリング

## 動作確認
- ローカル環境で動作確認済み
- 各種バリデーション動作確認済み
- コピー機能動作確認済み
- レスポンシブデザイン動作確認済み

## スクリーンショット
<img width="1512" height="864" alt="スクリーンショット 2025-11-16 0 23 02" src="https://github.com/user-attachments/assets/1c7d7a14-f9e5-41a9-a9b7-969fc2935e4c" />
