### PR TITLE
feat: 静的ページ（利用規約、プライバシーポリシー、お問い合わせ）を実装

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -198,6 +198,8 @@ body {
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
   transition: all 0.2s;
 }
 
@@ -846,7 +848,7 @@ body {
 }
 
 .card-value {
-  font-size: 2rem;
+  font-size: 1.5rem;
   font-weight: 700;
   color: #333;
   margin: 0.5rem 0;
@@ -926,5 +928,266 @@ body {
 
   .card-value {
     font-size: 1.5rem;
+  }
+}
+
+/* ===========================
+   静的ページ
+=========================== */
+.static-page-container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.static-page-header {
+  text-align: center;
+  margin-bottom: 3rem;
+  padding-bottom: 2rem;
+  border-bottom: 3px solid #2563eb;
+}
+
+.static-page-title {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #1e40af;
+  margin-bottom: 1rem;
+}
+
+.static-page-subtitle {
+  font-size: 1.1rem;
+  color: #64748b;
+  margin-top: 1rem;
+}
+
+.static-page-updated {
+  font-size: 0.9rem;
+  color: #94a3b8;
+  margin-top: 0.5rem;
+}
+
+.static-page-content {
+  background: white;
+  padding: 3rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  margin-bottom: 2rem;
+}
+
+.content-section {
+  margin-bottom: 3rem;
+}
+
+.content-section:last-child {
+  margin-bottom: 0;
+}
+
+.section-heading {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #1e40af;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid #e2e8f0;
+}
+
+.section-text {
+  font-size: 1rem;
+  line-height: 1.8;
+  color: #334155;
+  margin-bottom: 1rem;
+}
+
+.section-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 1rem 0;
+}
+
+.section-list li {
+  padding-left: 1.5rem;
+  margin-bottom: 0.75rem;
+  position: relative;
+  line-height: 1.6;
+  color: #334155;
+}
+
+.section-list li::before {
+  content: "•";
+  position: absolute;
+  left: 0;
+  color: #2563eb;
+  font-weight: bold;
+  font-size: 1.2rem;
+}
+
+.inline-link {
+  color: #2563eb;
+  text-decoration: underline;
+  transition: color 0.2s;
+}
+
+.inline-link:hover {
+  color: #1e40af;
+}
+
+.content-footer {
+  text-align: right;
+  margin-top: 3rem;
+  padding-top: 2rem;
+  border-top: 2px solid #e2e8f0;
+  color: #64748b;
+  font-style: italic;
+}
+
+.static-page-actions {
+  text-align: center;
+  margin-top: 2rem;
+}
+
+/* お問い合わせページ用のスタイル */
+.contact-card {
+  background: linear-gradient(135deg, #f8fafc 0%, #e0e7ff 100%);
+  border: 2px solid #2563eb;
+  border-radius: 12px;
+  padding: 2rem;
+  margin: 1.5rem 0;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.contact-card-icon {
+  width: 64px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  flex-shrink: 0;
+}
+
+.github-icon {
+  background-color: #1e293b;
+  color: white;
+}
+
+.form-icon {
+  background: linear-gradient(135deg, #4285f4 0%, #34a853 100%);
+  color: white;
+}
+
+.contact-card-icon svg {
+  width: 36px;
+  height: 36px;
+}
+
+.contact-card-content {
+  flex: 1;
+}
+
+.contact-card-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #1e40af;
+  margin-bottom: 0.5rem;
+}
+
+.contact-card-text {
+  font-size: 0.95rem;
+  color: #64748b;
+  margin-bottom: 1rem;
+}
+
+.btn-outline {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  background-color: white;
+  color: #2563eb;
+  border: 2px solid #2563eb;
+  border-radius: 8px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: all 0.2s;
+}
+
+.btn-outline:hover {
+  background-color: #2563eb;
+  color: white;
+}
+
+.external-icon {
+  width: 18px;
+  height: 18px;
+}
+
+/* FAQ */
+.faq-item {
+  background-color: #f8fafc;
+  padding: 1.5rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  border-left: 4px solid #2563eb;
+}
+
+.faq-question {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1e40af;
+  margin-bottom: 0.75rem;
+}
+
+.faq-answer {
+  font-size: 1rem;
+  line-height: 1.7;
+  color: #334155;
+}
+
+/* 静的ページのレスポンシブ対応 */
+@media (max-width: 768px) {
+  .static-page-container {
+    padding: 1rem;
+  }
+
+  .static-page-title {
+    font-size: 2rem;
+  }
+
+  .static-page-content {
+    padding: 2rem 1.5rem;
+  }
+
+  .section-heading {
+    font-size: 1.25rem;
+  }
+
+  .contact-card {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .contact-card-icon {
+    width: 56px;
+    height: 56px;
+  }
+}
+
+/* 印刷用スタイル */
+@media print {
+  .static-page-actions,
+  .btn,
+  .btn-outline {
+    display: none;
+  }
+
+  .static-page-content {
+    box-shadow: none;
+    border: 1px solid #e2e8f0;
+  }
+
+  .content-section {
+    page-break-inside: avoid;
   }
 }

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,10 @@
+class StaticPagesController < ApplicationController
+  def terms
+  end
+
+  def privacy
+  end
+
+  def contact
+  end
+end

--- a/app/helpers/static_pages_helper.rb
+++ b/app/helpers/static_pages_helper.rb
@@ -1,0 +1,2 @@
+module StaticPagesHelper
+end

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,5 +1,5 @@
 <footer class="footer">
-  <%= link_to "利用規約", "#", class: "footer-link" %>
-  <%= link_to "プライバシーポリシー", "#", class: "footer-link" %>
-  <%= link_to "お問い合わせ", "#", class: "footer-link" %>
+  <%= link_to "利用規約", terms_path, class: "footer-link" %>
+  <%= link_to "プライバシーポリシー", privacy_path, class: "footer-link" %>
+  <%= link_to "お問い合わせ", contact_path, class: "footer-link" %>
 </footer>

--- a/app/views/static_pages/contact.html.erb
+++ b/app/views/static_pages/contact.html.erb
@@ -1,0 +1,89 @@
+<div class="static-page-container">
+  <div class="static-page-header">
+    <h1 class="static-page-title">お問い合わせ</h1>
+    <p class="static-page-subtitle">サービスに関するご質問やご要望がございましたら、お気軽にお問い合わせください。</p>
+  </div>
+
+  <div class="static-page-content">
+    <section class="content-section">
+      <h2 class="section-heading">お問い合わせ方法</h2>
+      <p class="section-text">
+        QA-ToolKitに関するお問い合わせは、以下のフォームから受け付けております。
+        ご質問、ご要望、不具合報告など、お気軽にお送りください。
+      </p>
+    </section>
+
+    <section class="content-section">
+      <h2 class="section-heading">お問い合わせフォーム</h2>
+      <p class="section-text">
+        下記のボタンからGoogleフォームを開いてお問い合わせください。
+        匿名でのお問い合わせも可能です。
+      </p>
+      <div class="contact-card">
+        <div class="contact-card-icon form-icon">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-5 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z"/>
+          </svg>
+        </div>
+        <div class="contact-card-content">
+          <h3 class="contact-card-title">Googleフォーム</h3>
+          <p class="contact-card-text">フォームからお問い合わせください（匿名可）</p>
+          <a href="https://forms.gle/np6CrU2BDCGcHFXWA" target="_blank" rel="noopener noreferrer" class="btn btn-outline">
+            お問い合わせフォームを開く
+            <svg xmlns="http://www.w3.org/2000/svg" class="external-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <h2 class="section-heading">お問い合わせの際のお願い</h2>
+      <ul class="section-list">
+        <li>お問い合わせの際は、できるだけ具体的な内容をご記載ください</li>
+        <li>バグ報告の場合は、再現手順や発生環境（ブラウザ、OS等）をお知らせください</li>
+        <li>機能要望の場合は、どのような場面でその機能が必要なのかをお知らせください</li>
+        <li>回答までにお時間をいただく場合がございます</li>
+      </ul>
+    </section>
+
+    <section class="content-section">
+      <h2 class="section-heading">よくある質問</h2>
+      
+      <div class="faq-item">
+        <h3 class="faq-question">Q. 生成したデータは保存されますか？</h3>
+        <p class="faq-answer">
+          A. いいえ、保存されません。すべてのデータはブラウザ上でリアルタイムに生成され、
+          サーバーに送信・保存されることはありません。
+        </p>
+      </div>
+
+      <div class="faq-item">
+        <h3 class="faq-question">Q. 利用に料金はかかりますか？</h3>
+        <p class="faq-answer">
+          A. 完全無料でご利用いただけます。今後も無料での提供を継続する予定です。
+        </p>
+      </div>
+
+      <div class="faq-item">
+        <h3 class="faq-question">Q. 商用利用は可能ですか？</h3>
+        <p class="faq-answer">
+          A. はい、商用利用も可能です。業務でのテストデータ生成などに自由にご利用ください。
+        </p>
+      </div>
+
+      <div class="faq-item">
+        <h3 class="faq-question">Q. 新しい機能のリクエストはできますか？</h3>
+        <p class="faq-answer">
+          A. はい、GitHubのIssueから機能要望をお送りください。
+          可能な範囲で対応させていただきます。
+        </p>
+      </div>
+    </section>
+  </div>
+
+  <div class="static-page-actions">
+    <%= link_to "トップページへ戻る", root_path, class: "btn btn-primary" %>
+  </div>
+</div>

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,0 +1,105 @@
+<div class="static-page-container">
+  <div class="static-page-header">
+    <h1 class="static-page-title">プライバシーポリシー</h1>
+    <p class="static-page-updated">最終更新日: <%= Date.today.strftime("%Y年%m月%d日") %></p>
+  </div>
+
+  <div class="static-page-content">
+    <section class="content-section">
+      <h2 class="section-heading">個人情報の取り扱いについて</h2>
+      <p class="section-text">
+        QA-ToolKit（以下、「当サービス」といいます。）は、ユーザーの個人情報の取り扱いについて、以下のとおりプライバシーポリシーを定めます。
+      </p>
+    </section>
+
+    <section class="content-section">
+      <h2 class="section-heading">第1条（個人情報の定義）</h2>
+      <p class="section-text">
+        「個人情報」とは、個人情報保護法にいう「個人情報」を指すものとし、生存する個人に関する情報であって、
+        当該情報に含まれる氏名、生年月日、住所、電話番号、連絡先その他の記述等により特定の個人を識別できる情報を指します。
+      </p>
+    </section>
+
+    <section class="content-section">
+      <h2 class="section-heading">第2条（個人情報の収集方法）</h2>
+      <p class="section-text">
+        当サービスは、基本的にユーザーの個人情報を収集しません。
+        当サービスは登録不要で、アクセスログ以外の情報を保存することはありません。
+      </p>
+    </section>
+
+    <section class="content-section">
+      <h2 class="section-heading">第3条（アクセスログについて）</h2>
+      <p class="section-text">
+        当サービスでは、サービスの改善とセキュリティ確保のため、以下のアクセスログを収集する場合があります。
+      </p>
+      <ul class="section-list">
+        <li>アクセス日時</li>
+        <li>IPアドレス</li>
+        <li>ブラウザの種類とバージョン</li>
+        <li>参照元URL</li>
+        <li>アクセスしたページのURL</li>
+      </ul>
+      <p class="section-text">
+        これらの情報は統計的な分析のみに使用され、個人を特定するために使用されることはありません。
+      </p>
+    </section>
+
+    <section class="content-section">
+      <h2 class="section-heading">第4条（Cookieについて）</h2>
+      <p class="section-text">
+        当サービスでは、サービスの利便性向上のためにCookieを使用することがあります。
+        Cookieとは、Webサーバーからユーザーのブラウザに送信される小さなテキストファイルで、ユーザーのコンピュータに保存されます。
+      </p>
+      <p class="section-text">
+        Cookieの使用を希望されない場合は、ブラウザの設定でCookieを無効にすることができます。
+        ただし、Cookieを無効にした場合、サービスの一部機能が正常に動作しない可能性があります。
+      </p>
+    </section>
+
+    <section class="content-section">
+      <h2 class="section-heading">第5条（生成されたデータについて）</h2>
+      <p class="section-text">
+        当サービスで生成されたテストデータやダミーデータは、サーバー上に保存されません。
+        すべての生成処理はリアルタイムで行われ、ページを離れると自動的に削除されます。
+      </p>
+    </section>
+
+    <section class="content-section">
+      <h2 class="section-heading">第6条（第三者への提供）</h2>
+      <p class="section-text">
+        当サービスは、法令に基づく場合を除き、ユーザーの同意なく個人情報を第三者に提供することはありません。
+      </p>
+    </section>
+
+    <section class="content-section">
+      <h2 class="section-heading">第7条（セキュリティ）</h2>
+      <p class="section-text">
+        当サービスは、個人情報の漏洩、滅失またはき損の防止その他の個人情報の安全管理のために必要かつ適切な措置を講じます。
+      </p>
+    </section>
+
+    <section class="content-section">
+      <h2 class="section-heading">第8条（プライバシーポリシーの変更）</h2>
+      <p class="section-text">
+        本ポリシーの内容は、法令その他本ポリシーに別段の定めのある事項を除いて、ユーザーに通知することなく変更することができるものとします。
+        変更後のプライバシーポリシーは、当サービス上に掲載された時点から効力を生じるものとします。
+      </p>
+    </section>
+
+    <section class="content-section">
+      <h2 class="section-heading">第9条（お問い合わせ窓口）</h2>
+      <p class="section-text">
+        本ポリシーに関するお問い合わせは、<%= link_to "お問い合わせページ", contact_path, class: "inline-link" %>からお願いいたします。
+      </p>
+    </section>
+
+    <div class="content-footer">
+      <p>以上</p>
+    </div>
+  </div>
+
+  <div class="static-page-actions">
+    <%= link_to "トップページへ戻る", root_path, class: "btn btn-primary" %>
+  </div>
+</div>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,0 +1,83 @@
+<div class="static-page-container">
+  <div class="static-page-header">
+    <h1 class="static-page-title">利用規約</h1>
+    <p class="static-page-updated">最終更新日: <%= Date.today.strftime("%Y年%m月%d日") %></p>
+  </div>
+
+  <div class="static-page-content">
+    <section class="content-section">
+      <h2 class="section-heading">第1条（適用）</h2>
+      <p class="section-text">
+        本規約は、QA-ToolKit（以下、「当サービス」といいます。）の利用に関する条件を定めるものです。
+        当サービスをご利用いただく際には、本規約の全文をお読みいただき、内容をご理解・ご同意いただいた上でご利用ください。
+      </p>
+    </section>
+
+    <section class="content-section">
+      <h2 class="section-heading">第2条（利用登録）</h2>
+      <p class="section-text">
+        当サービスは登録不要で無料でご利用いただけます。
+        当サービスにアクセスし、機能を利用することで、本規約に同意したものとみなします。
+      </p>
+    </section>
+
+    <section class="content-section">
+      <h2 class="section-heading">第3条（禁止事項）</h2>
+      <p class="section-text">
+        ユーザーは、当サービスの利用にあたり、以下の行為をしてはなりません。
+      </p>
+      <ul class="section-list">
+        <li>法令または公序良俗に違反する行為</li>
+        <li>犯罪行為に関連する行為</li>
+        <li>当サービスの運営を妨害するおそれのある行為</li>
+        <li>他のユーザーまたは第三者の知的財産権、肖像権、プライバシー、名誉その他の権利または利益を侵害する行為</li>
+        <li>当サービスに過度な負荷をかける行為</li>
+        <li>不正アクセスをし、またはこれを試みる行為</li>
+        <li>その他、当サービスが不適切と判断する行為</li>
+      </ul>
+    </section>
+
+    <section class="content-section">
+      <h2 class="section-heading">第4条（サービスの内容の変更等）</h2>
+      <p class="section-text">
+        当サービスは、ユーザーに通知することなく、当サービスの内容を変更し、または当サービスの提供を中止することができるものとします。
+        これによってユーザーに生じた損害について一切の責任を負いません。
+      </p>
+    </section>
+
+    <section class="content-section">
+      <h2 class="section-heading">第5条（免責事項）</h2>
+      <p class="section-text">
+        当サービスは、当サービスに起因してユーザーに生じたあらゆる損害について一切の責任を負いません。
+        ただし、当サービスに関する契約が消費者契約法に定める消費者契約となる場合、この免責規定は適用されません。
+      </p>
+      <p class="section-text">
+        前項ただし書に定める場合であっても、当サービスは、過失（重過失を除きます。）による債務不履行または不法行為によりユーザーに生じた損害のうち特別な事情から生じた損害については、一切の責任を負いません。
+      </p>
+    </section>
+
+    <section class="content-section">
+      <h2 class="section-heading">第6条（サービス内容の変更等）</h2>
+      <p class="section-text">
+        当サービスは、ユーザーへの事前の告知をもって、本規約を変更することができるものとします。
+        変更後の規約は、当サービス上に掲載された時点から効力を生じるものとします。
+      </p>
+    </section>
+
+    <section class="content-section">
+      <h2 class="section-heading">第7条（準拠法・裁判管轄）</h2>
+      <p class="section-text">
+        本規約の解釈にあたっては、日本法を準拠法とします。
+        当サービスに関して紛争が生じた場合には、当サービス運営者の所在地を管轄する裁判所を専属的合意管轄とします。
+      </p>
+    </section>
+
+    <div class="content-footer">
+      <p>以上</p>
+    </div>
+  </div>
+
+  <div class="static-page-actions">
+    <%= link_to "トップページへ戻る", root_path, class: "btn btn-primary" %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,4 +23,9 @@ Rails.application.routes.draw do
   post "tools/generate_address", to: "tools#generate_address"
   get "tools/test_class_analysis", to: "tools#test_class_analysis"
   post "tools/analyze_boundary", to: "tools#analyze_boundary"
+
+  # Static pages
+  get "terms", to: "static_pages#terms"
+  get "privacy", to: "static_pages#privacy"
+  get "contact", to: "static_pages#contact"
 end

--- a/spec/helpers/static_pages_helper_spec.rb
+++ b/spec/helpers/static_pages_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the StaticPagesHelper. For example:
+#
+# describe StaticPagesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe StaticPagesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe "StaticPages", type: :request do
+  describe "GET /terms" do
+    it "returns http success" do
+      get "/static_pages/terms"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /privacy" do
+    it "returns http success" do
+      get "/static_pages/privacy"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /contact" do
+    it "returns http success" do
+      get "/static_pages/contact"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/static_pages/contact.html.erb_spec.rb
+++ b/spec/views/static_pages/contact.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "static_pages/contact.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/static_pages/privacy.html.erb_spec.rb
+++ b/spec/views/static_pages/privacy.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "static_pages/privacy.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/static_pages/terms.html.erb_spec.rb
+++ b/spec/views/static_pages/terms.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "static_pages/terms.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
利用規約、プライバシーポリシー、お問い合わせページを実装しました。

## 実装内容
### 利用規約ページ (/terms)
- 7条項（適用、登録、禁止事項、変更、免責、規約変更、準拠法）
- 最終更新日を自動表示

### プライバシーポリシーページ (/privacy)
- 9条項（定義、収集方法、アクセスログ、Cookie、データ保存、第三者提供、セキュリティ、変更、問い合わせ）
- お問い合わせページへの内部リンク

### お問い合わせページ (/contact)
- Googleフォーム連携（https://forms.gle/np6CrU2BDCGcHFXWA）
- FAQ4項目（データ保存、料金、商用利用、機能リクエスト）

### その他
- フッターのリンクを実際のパスに更新
- ボタンの下線を削除
- レスポンシブデザイン対応
- 印刷用スタイル対応